### PR TITLE
Fix fallback context handling

### DIFF
--- a/conversation_manager.py
+++ b/conversation_manager.py
@@ -151,7 +151,7 @@ class ConversationManager:
         # Ensure the context is not empty
         if not relevant_messages:
             print("Warning: Empty context! Returning basic message list.")
-            return []
+            return recent_messages
         return relevant_messages
     
     def extract_keywords(self, text):


### PR DESCRIPTION
## Summary
- adjust `get_relevant_context` to return recent messages instead of an empty list when the context is empty

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68558b7e30dc83228333ac159d4c8678