### PR TITLE
Add autonomous core prompt updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Astra
+
+Astra is an experimental conversational companion powered by GPT models. The project
+combines memory management, emotion analysis and dual model integration.
+
+## Requirements
+* Python 3.11+
+* An OpenAI API key available in `.env` as `OPENAI_API_KEY`
+
+## Running
+1. Install dependencies (if any) and ensure the API key is set in `.env`.
+2. Start the application:
+   ```bash
+   python astra_app.py
+   ```
+3. Interact with Astra in the console. Type `выход` to quit.
+
+The directory `astra_data/` stores persistent files such as `astra_core_prompt.txt`
+and emotional memories. Commands like `сохрани в core_prompt` allow updating the
+core prompt, while Astra can autonomously append lines if `allow_core_update` is
+enabled in `AstraMemory`.

--- a/astra_command_parser.py
+++ b/astra_command_parser.py
@@ -296,5 +296,19 @@ class AstraCommandParser:
         self.memory.chat.conversation_manager.save_history_to_disk()
         
         history_count = len(self.memory.chat.conversation_manager.full_conversation_history)
-        
-        return f"Я сохранила историю нашего диалога ({history_count} сообщений)."    
+
+        return f"Я сохранила историю нашего диалога ({history_count} сообщений)."
+
+    def _handle_save_to_core_prompt(self, text, text_lower):
+        """Сохраняет заданный текст в core_prompt"""
+        start = text_lower.find("сохрани в core_prompt")
+        if start == -1:
+            return "Не поняла, что нужно сохранить."
+        content = text[start + len("сохрани в core_prompt"):].strip().strip('"')
+        if not content:
+            return "Не указано, что сохранить в core_prompt."
+        if hasattr(self.memory, 'append_to_core_prompt'):
+            success = self.memory.append_to_core_prompt(content)
+        else:
+            success = self.memory.save_to_core_prompt(content)
+        return "Добавила в core_prompt." if success else "Не удалось сохранить." 

--- a/astra_diary.py
+++ b/astra_diary.py
@@ -345,6 +345,8 @@ class AstraDiary:
             return False
         
         # Добавляем новую строку в core_prompt
+        if hasattr(self.memory, 'append_to_core_prompt'):
+            return self.memory.append_to_core_prompt(realization)
         return self.memory.save_to_core_prompt(realization)
     
     def generate_dream(self):

--- a/astra_memory.py
+++ b/astra_memory.py
@@ -51,6 +51,10 @@ class AstraMemory:
         self.relationship_memory = {}
         self.current_state = {}
         self.memory_log = []
+
+        # Дополнительные флаги поведения
+        self.allow_core_update = False
+        self.autonomous_memory = False
         
         # Загружаем память один раз при инициализации
         self.load_all_memory()
@@ -565,6 +569,12 @@ class AstraMemory:
         file_path = self.get_file_path(filename)
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def save_text_file(self, filename, text):
+        """Сохраняет строку в текстовый файл"""
+        file_path = self.get_file_path(filename)
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(text)
     
     def append_to_jsonl(self, filename, data):
         """Добавляет запись в JSONL файл"""
@@ -594,6 +604,18 @@ class AstraMemory:
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(self.core_prompt)
         return True
+
+    def append_to_core_prompt(self, new_line: str):
+        """Добавляет строку в core_prompt, если обновление разрешено"""
+        if not self.allow_core_update:
+            return False
+        line = new_line.strip()
+        if line and line not in self.core_prompt:
+            self.core_prompt += f"\n{line}"
+            self.save_text_file(ASTRA_CORE_FILE, self.core_prompt)
+            print("\U0001F4DD Astra обновила свой core_prompt.")
+            return True
+        return False
     
     def load_current_state(self):
         """Загружает текущее эмоциональное состояние"""


### PR DESCRIPTION
## Summary
- add flags `allow_core_update` and `autonomous_memory` in `AstraMemory`
- implement `append_to_core_prompt` and helper `save_text_file`
- handle `сохрани в core_prompt` command
- update `AstraDiary` to use new append method
- document setup and usage in new `README`

## Testing
- `python -m py_compile astra_memory.py astra_diary.py astra_command_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a9adfbc88322a8616207f5008342