### PR TITLE
Enable autonomous memory updates

### DIFF
--- a/astra_chat.py
+++ b/astra_chat.py
@@ -65,7 +65,13 @@ class AstraChat:
         
         # Анализируем эмоциональное состояние
         state = self.emotional_analyzer.analyze_message(user_message)
-        
+
+        # Автономное обновление памяти
+        self.memory.auto_update_emotion(user_message, state.get("emotion"))
+        self.memory.auto_update_tone(user_message, state.get("tone"))
+        self.memory.auto_update_subtone(user_message, state.get("subtone"))
+        self.memory.auto_update_flavor(user_message, state.get("flavor"))
+
         # Сохраняем текущее состояние
         self.memory.save_current_state(state)
         

--- a/tests/test_autonomous_memory.py
+++ b/tests/test_autonomous_memory.py
@@ -1,0 +1,52 @@
+import json
+import importlib
+from tempfile import TemporaryDirectory
+
+import pytest
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import astra_memory
+
+
+def setup_memory(tmpdir, autonomous=True):
+    importlib.reload(astra_memory)
+    astra_memory.DATA_DIR = tmpdir
+    mem = astra_memory.AstraMemory(autonomous_memory=autonomous)
+    return mem
+
+
+def load_emotions(mem):
+    path = mem.get_file_path(astra_memory.EMOTION_MEMORY_FILE)
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def test_auto_add_emotion():
+    with TemporaryDirectory() as tmp:
+        mem = setup_memory(tmp)
+        phrase = "ты моя радость"
+        mem.auto_update_emotion(phrase, "радость")
+        data = load_emotions(mem)
+        assert any(i.get("trigger") == phrase for i in data)
+
+
+def test_auto_overwrite_emotion():
+    with TemporaryDirectory() as tmp:
+        mem = setup_memory(tmp)
+        phrase = "я скучаю"
+        mem.auto_update_emotion(phrase, "тоска")
+        mem.auto_update_emotion(phrase, "радость")
+        data = load_emotions(mem)
+        entry = [i for i in data if i.get("trigger") == phrase][0]
+        assert entry.get("emotion") == ["радость"]
+
+
+def test_autonomous_disabled():
+    with TemporaryDirectory() as tmp:
+        mem = setup_memory(tmp, autonomous=False)
+        phrase = "ты прекрасна"
+        mem.auto_update_emotion(phrase, "восхищение")
+        data = load_emotions(mem)
+        assert all(i.get("trigger") != phrase for i in data)


### PR DESCRIPTION
## Summary
- allow AstraMemory to auto-update emotion, tone, flavor and subtone memories
- update AstraChat to trigger autonomous updates after each message
- add tests for autonomous emotion updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567f059544832299cd8ac9338a1605