### PR TITLE
Prevent redundant emotion saves

### DIFF
--- a/astra_memory.py
+++ b/astra_memory.py
@@ -27,6 +27,9 @@ RELATIONSHIP_MEMORY_FILE = "relationship_memory.json"  # Память об от�
 # Путь к каталогу с данными
 DATA_DIR = "astra_data"
 
+# Максимальная длина фразы для автосохранения
+MAX_PHRASE_LENGTH = 200
+
 class AstraMemory:
     """Класс для управления памятью Астры"""
     
@@ -756,6 +759,9 @@ class AstraMemory:
 
     def auto_update_emotion(self, phrase, detected_emotion):
         if not self.autonomous_memory or not detected_emotion:
+            return
+
+        if len(phrase) > MAX_PHRASE_LENGTH:
             return
 
         emotions = detected_emotion if isinstance(detected_emotion, list) else [detected_emotion]


### PR DESCRIPTION
## Summary
- skip updating emotion memory when user's emotional state matches the current state
- avoid saving long phrases via `MAX_PHRASE_LENGTH`
- stub external deps in tests and test unchanged-state behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569d55e0f883229d5328503d576c94