### PR TITLE
Improve phrase normalization and fix README newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ The directory `astra_data/` stores persistent files such as `astra_core_prompt.t
 and emotional memories. Commands like `сохрани в core_prompt` allow updating the
 core prompt, while Astra can autonomously append lines if `allow_core_update` is
 enabled in `AstraMemory`.
+
+## Maintenance
+Run `scripts/cleanup_duplicates.py` to merge duplicate emotion records after updates.

--- a/scripts/cleanup_duplicates.py
+++ b/scripts/cleanup_duplicates.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import astra_memory
+
+
+def cleanup_emotion_memory():
+    mem = astra_memory.AstraMemory()
+    norm_dict = {}
+    for entry in mem.emotion_memory:
+        norm = mem._normalize_phrase(entry.get("trigger", ""))
+        if norm in norm_dict:
+            existing = norm_dict[norm]
+            # merge emotions
+            if entry.get("emotion"):
+                emotions = entry["emotion"] if isinstance(entry["emotion"], list) else [entry["emotion"]]
+                existing_emotions = existing.get("emotion", [])
+                if not isinstance(existing_emotions, list):
+                    existing_emotions = [existing_emotions]
+                existing["emotion"] = list(dict.fromkeys(existing_emotions + emotions))
+            # merge tone
+            if entry.get("tone") and not existing.get("tone"):
+                existing["tone"] = entry["tone"]
+            # merge subtone
+            if entry.get("subtone"):
+                subs = entry["subtone"] if isinstance(entry["subtone"], list) else [entry["subtone"]]
+                existing_subs = existing.get("subtone", [])
+                if not isinstance(existing_subs, list):
+                    existing_subs = [existing_subs]
+                existing["subtone"] = list(dict.fromkeys(existing_subs + subs))
+            # merge flavor
+            if entry.get("flavor"):
+                fl = entry["flavor"] if isinstance(entry["flavor"], list) else [entry["flavor"]]
+                existing_fl = existing.get("flavor", [])
+                if not isinstance(existing_fl, list):
+                    existing_fl = [existing_fl]
+                existing["flavor"] = list(dict.fromkeys(existing_fl + fl))
+        else:
+            new_entry = entry.copy()
+            new_entry["trigger"] = norm
+            norm_dict[norm] = new_entry
+    mem.emotion_memory = list(norm_dict.values())
+    mem.save_json_file(astra_memory.EMOTION_MEMORY_FILE, mem.emotion_memory)
+    print("Duplicates cleaned. Total entries:", len(mem.emotion_memory))
+
+
+if __name__ == "__main__":
+    cleanup_emotion_memory()

--- a/tests/test_autonomous_memory.py
+++ b/tests/test_autonomous_memory.py
@@ -50,3 +50,13 @@ def test_autonomous_disabled():
         mem.auto_update_emotion(phrase, "восхищение")
         data = load_emotions(mem)
         assert all(i.get("trigger") != phrase for i in data)
+
+
+def test_normalization_deduplication():
+    with TemporaryDirectory() as tmp:
+        mem = setup_memory(tmp)
+        mem.add_emotion_to_phrase("Привет!", "радость")
+        mem.add_emotion_to_phrase("привет", "радость")
+        data = load_emotions(mem)
+        assert len(data) == 1
+        assert data[0]["trigger"] == "привет"


### PR DESCRIPTION
## Summary
- normalize phrases for consistent lookups
- deduplicate memory entries using normalized forms
- add a script to clean up duplicate emotion records
- document the cleanup step
- add newline at end of README to avoid merge conflicts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68569d5659808322bd73413a0c9e1beb