### PR TITLE
Improve emotion memory deduplication

### DIFF
--- a/tests/test_autonomous_memory.py
+++ b/tests/test_autonomous_memory.py
@@ -77,3 +77,21 @@ def test_normalization_deduplication():
         data = load_emotions(mem)
         assert len(data) == 1
         assert data[0]["trigger"] == "привет"
+
+
+def test_semantic_deduplication_same_emotion():
+    with TemporaryDirectory() as tmp:
+        mem = setup_memory(tmp)
+        mem.add_emotion_to_phrase("Привет, мой друг!", "радость")
+        mem.add_emotion_to_phrase("привет мой дорогой друг", "радость")
+        data = load_emotions(mem)
+        assert len(data) == 1
+
+
+def test_semantic_allows_new_emotion():
+    with TemporaryDirectory() as tmp:
+        mem = setup_memory(tmp)
+        mem.add_emotion_to_phrase("как дела", "радость")
+        mem.add_emotion_to_phrase("как ты поживаешь", "грусть")
+        data = load_emotions(mem)
+        assert len(data) == 2


### PR DESCRIPTION
## Summary
- implement semantic comparison with SequenceMatcher for emotion memory
- prevent duplicates by checking semantic similarity and emotional data
- auto update functions rely on improved deduplication
- add tests for semantic deduplication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685712fa5b388322b51659330e4cdd3e