### PR TITLE
Add prioritized relevance strategies

### DIFF
--- a/memory_extractor.py
+++ b/memory_extractor.py
@@ -204,7 +204,12 @@ class MemoryExtractor:
         
         # Определяем релевантность фрагментов используя выбранную модель
         relevant_fragments = self.intent_analyzer.get_semantic_relevance(
-            user_message, all_fragments, model=model_to_use
+            user_message,
+            all_fragments,
+            model=model_to_use,
+            intent=intent,
+            strategy="compact_relevance",
+            memory_token_limit=800,
         )
         
         # Формируем результат


### PR DESCRIPTION
## Summary
- extend `get_semantic_relevance` with strategy, intent and token limit
- rank memories with emotional weight priority and support compact/verbose modes
- restrict context size in `MemoryExtractor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685715a5b9c88322bfbee7638c981df3