### PR TITLE
Implement emotional reflection

### DIFF
--- a/emotional_analyzer.py
+++ b/emotional_analyzer.py
@@ -36,8 +36,8 @@ class EmotionalAnalyzer:
         if trigger_state:
             return trigger_state
         
-        # Используем обычный анализ
-        return self.memory.decide_response_emotion(message)
+        # Используем рефлексивный анализ
+        return self.memory.reflective_state_for_message(message)
     
     def detect_emotional_markers(self, message):
         """


### PR DESCRIPTION
## Summary
- enhance memory to recommend emotional state based on semantic lookup
- smooth transitions using previous state for continuity
- update emotional analyzer to use reflective state logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685718e662a883229a721997daf277e4