### PR TITLE
Add token limit management

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ enabled in `AstraMemory`.
 
 ## Maintenance
 Run `scripts/cleanup_duplicates.py` to merge duplicate emotion records after updates.
+
+## Token handling
+`AstraChat.generate_response` uses `tiktoken` to approximate how many tokens will be sent to the API. If the existing context plus the `max_tokens` setting would exceed about 9500 tokens, the oldest messages in the relevant context are dropped until the request fits this limit. This prevents hitting the GPT-4o hard cap while still returning up to 2000 new tokens.


### PR DESCRIPTION
## Summary
- trim early context if estimated prompt tokens plus `max_tokens` exceeds 9500
- fall back to a simple estimator when `tiktoken` isn't installed
- document token limit handling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685940a4f8a4832286dd764654799007