### PR TITLE
Add detailed memory search logging

### DIFF
--- a/dual_model_integrator.py
+++ b/dual_model_integrator.py
@@ -76,8 +76,8 @@ class DualModelIntegrator:
         
         # Определяем, нужны ли глубокие воспоминания
         intent = intent_data.get("intent", "")
-        deep_memory_needed = intent in ["intimate", "about_relationship", "memory_recall"]
-        memory_model = "gpt-4" if deep_memory_needed else "gpt-3.5-turbo"
+        memory_model = "gpt-3.5-turbo"
+        self.log_step("Memory Model", memory_model)
         
         # Шаг 3: Извлекаем релевантные воспоминания с выбранной моделью
         memories_data = self.memory_extractor.extract_relevant_memories(


### PR DESCRIPTION
## Summary
- log token usage and debugging info for intent and style analyzers
- trace memory search steps in `MemoryExtractor`
- default memory search to use GPT‑3.5
- always use GPT‑3.5 for memory retrieval in `DualModelIntegrator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867041bef08832292e1f0ed70ca2bb2